### PR TITLE
Add missing BYD and Proterra bus fleets

### DIFF
--- a/pages/posts/ttc.mdx
+++ b/pages/posts/ttc.mdx
@@ -2012,10 +2012,12 @@ Email: gu.rongbin99@gmail.com
 | Nova Bus LFS     | Diesel      | 2018 - Rebuilt 2024      | 3100-3369        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_3100-3369#Details) |
 | Nova Bus LFS HEV | Hybrid      | 2018 - 2019              | 3400-3654        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_3400-3654#Details) |
 | New Flyer XE40 Charge    | Electric | 2019                | 3700-3724        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_3700-3724#Details) |
+| Proterra Catalyst BE40   | Electric | 2019                | 3725-3749        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_3725-3749#Details) |
+| BYD Auto K9M             | Electric | 2020                | 3750-3759        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_3750-3759#Details) |
 | New Flyer XDE40          | Hybrid   | 2023                | 7200-7333        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_7200-7333#Details) |
 | Nova Bus LFS HEV         | Hybrid   | 2023                | 7000-7133        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_7000-7133#Details) |
 | New Flyer XDE60*         | Hybrid   | 2023                | 9400-9467        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_9400-9467#Details) |
-| New Flyer XE40 Charge NG | Electric | 2025?               | 6000-6203        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_6000-6203#Details) |
+| New Flyer XE40 Charge NG | Electric | 2024                | 6000-6203        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_6000-6203#Details) |
 | Nova Bus LFSe+           | Electric | 2025?               | 6600-6735        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_6600-6735#Details) |
 
 #### Streetcars (*articulated)
@@ -2036,7 +2038,7 @@ Email: gu.rongbin99@gmail.com
 | H6               | Electric    | 1986 - Retired 2014                | 5810-5935        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_5810-5935#Details) |
 | T1               | Electric    | 1997 - Pending Retirement (2030?)  | 5000-5371        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_5000-5371#Details) |
 | Toronto Rocket   | Electric    | 2011                      | 5381-6136 <br/> 6141-6196 | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_5381-6136,_6141-6196#Details) |
-| New Line 2 Subways | Electric    | 2030?                     | Unknown        |  |
+| New Line 2 Subways | Electric  | 2030?                     | Unknown                   |  |
 
 #### LRVs (Light Rail Vehicles)
 
@@ -2046,4 +2048,4 @@ Email: gu.rongbin99@gmail.com
 | [Line 5: Eglinton LRT](https://en.wikipedia.org/wiki/Line_5_Eglinton) Flexity Freedom    | Electric    | 2025? (Pending Opening)            | 6200-6275        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_6200-6275#Details) |
 | [Line 6: Finch West LRT](https://en.wikipedia.org/wiki/Line_6_Finch_West) Citadis Spirit | Electric    | 2025? (Pending Opening)            | 6500-6516        | [*<u>CPTDB Link</u>*](https://cptdb.ca/wiki/index.php/Toronto_Transit_Commission_6500-6516#Details) |
 
-*Last modified: 2024/12/10 by Rongbin Gu*
+*Last modified: 2024/12/24 by Rongbin Gu*


### PR DESCRIPTION
This PR adds the forgotten BYD and Proterra electric bus fleets to the TTC Fleet section.

**PR CHECKLIST**

- [x] My code follows the style guidelines of this project (variable naming, commenting, copyright, etc.)
- [x] I have performed a self-review of my code
- [x] Changes are clearly highlighted and easy to understand
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have meaningful commit messages that explain what was changed/committed
- [x] I have built and locally tested my changes
- [x] My changes generate no new errors or regressions (pending verification)
- [x] I have made corresponding changes to the documentation OR this is N/A
- [x] Documentation accurately reflects the current state of the project OR this is N/A
- [x] I have added tests that prove my fix is effective or that my feature works OR this is N/A
- [x] New and existing unit tests pass locally with my changes OR this is N/A
- [x] Any dependent changes have been merged and published in downstream modules OR this is N/A
- [x] All links are working and correct OR this is N/A
- [x] Spelling and grammar are correct
- [x] I have added the "READY FOR REVIEWS" tag when this PR is ready for reviews
