### PR TITLE
Fix Side Margins for Mobile

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -138,8 +138,32 @@ article {
 /* content container */
 article.x\:container {
   max-width: 1200px !important;
-  padding-left: 10rem !important;
-  padding-right: 10rem !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+
+/* Tablet and larger */
+@media (min-width: 768px) {
+  article.x\:container {
+    padding-left: 4rem !important;
+    padding-right: 4rem !important;
+  }
+}
+
+/* Desktop */
+@media (min-width: 1024px) {
+  article.x\:container {
+    padding-left: 8rem !important;
+    padding-right: 8rem !important;
+  }
+}
+
+/* Large desktop */
+@media (min-width: 1280px) {
+  article.x\:container {
+    padding-left: 10rem !important;
+    padding-right: 10rem !important;
+  }
 }
 
 .site-footer-text {


### PR DESCRIPTION
This PR fixes the side margins to allow content to be properly displayed on mobile screens. This regression was caused by https://github.com/Rongbin99/Rongbin99.github.io/pull/38

Changes:

- Implements mobile-first responsive padding for article.x\:container using media queries
- Scales padding from 1rem on mobile to 10rem on large desktop screens
- Uses standard responsive breakpoints (768px, 1024px, 1280px)

**PR CHECKLIST**

- [x] My code follows the style guidelines of this project (variable naming, commenting, copyright, etc.)
- [x] I have performed a self-review of my code
- [x] Changes are clearly highlighted and easy to understand
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have meaningful commit messages that explain what was changed/committed
- [x] I have built and locally tested my changes
- [x] My changes generate no new errors or regressions (pending verification)
- [x] I have made corresponding changes to the documentation OR this is N/A
- [x] Documentation accurately reflects the current state of the project OR this is N/A
- [x] I have added tests that prove my fix is effective or that my feature works OR this is N/A
- [x] New and existing unit tests pass locally with my changes OR this is N/A
- [x] Any dependent changes have been merged and published in downstream modules OR this is N/A
- [x] All links are working and correct OR this is N/A
- [x] Spelling and grammar are correct
- [x] I have added the "READY FOR REVIEWS" tag when this PR is ready for reviews
